### PR TITLE
Add stock list page and fix service worker

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -12,6 +12,7 @@
             <div class="logo">AI Stock Analyzer</div>
             <ul>
                 <li><a href="index.html">ホーム</a></li>
+                <li><a href="stocks.html">銘柄一覧</a></li>
                 <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
                 <li><a href="terms.html">利用規約</a></li>
                 <li><a href="contact.html">お問い合わせ</a></li>

--- a/index.html
+++ b/index.html
@@ -481,7 +481,7 @@
         <!-- Footer -->
         <div class="footer">
             <p>&copy; 2025 AI Stock Analyzer by <a href="https://x.com/appadaycreator" target="_blank">@appadaycreator</a></p>
-            <p><a href="privacy-policy.html">プライバシーポリシー</a> | <a href="terms.html">免責事項</a> | <a href="contact.html">お問い合わせ</a></p>
+            <p><a href="privacy-policy.html">プライバシーポリシー</a> | <a href="stocks.html">銘柄一覧</a> | <a href="terms.html">免責事項</a> | <a href="contact.html">お問い合わせ</a></p>
         </div>
     </div>
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -12,6 +12,7 @@
             <div class="logo">AI Stock Analyzer</div>
             <ul>
                 <li><a href="index.html">ホーム</a></li>
+                <li><a href="stocks.html">銘柄一覧</a></li>
                 <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
                 <li><a href="terms.html">利用規約</a></li>
                 <li><a href="contact.html">お問い合わせ</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -24,4 +24,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://appadaycreator.github.io/ai-stock-analyzer/stocks.html</loc>
+    <lastmod>2025-06-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>

--- a/stocks.html
+++ b/stocks.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>銘柄一覧 - AI Stock Analyzer</title>
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        th, td {
+            padding: 8px 12px;
+            border: 1px solid #ddd;
+            text-align: left;
+        }
+        th {
+            background: #f0f0f0;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="logo">AI Stock Analyzer</div>
+            <ul>
+                <li><a href="index.html">ホーム</a></li>
+                <li><a href="stocks.html">銘柄一覧</a></li>
+                <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
+                <li><a href="terms.html">利用規約</a></li>
+                <li><a href="contact.html">お問い合わせ</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section>
+            <h1>銘柄一覧</h1>
+            <p>AI Stock Analyzerで分析可能な銘柄の一覧です。</p>
+            <table>
+                <thead>
+                    <tr><th>銘柄コード</th><th>銘柄名</th></tr>
+                </thead>
+                <tbody id="stockList"></tbody>
+            </table>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 AI Stock Analyzer. All rights reserved.</p>
+    </footer>
+
+    <script>
+    const stockNames = {
+        '7203.T': 'トヨタ自動車',
+        '9984.T': 'ソフトバンクグループ',
+        '6758.T': 'ソニーグループ',
+        '8306.T': '三菱UFJフィナンシャル・グループ',
+        '6501.T': '日立製作所'
+    };
+    for (let i = 1301; i <= 1495; i++) {
+        stockNames[`${i}.T`] = `企業${i}`;
+    }
+    const tbody = document.getElementById('stockList');
+    Object.keys(stockNames).sort().forEach(code => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${code}</td><td>${stockNames[code]}</td>`;
+        tbody.appendChild(tr);
+    });
+    </script>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,17 +1,20 @@
-const CACHE_NAME = 'ai-stock-analyzer-v2';
+const CACHE_NAME = 'ai-stock-analyzer-v3';
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/privacy-policy.html',
-  '/terms.html',
-  '/contact.html',
-  '/manifest.json',
-  '/styles.css'
+  './',
+  './index.html',
+  './privacy-policy.html',
+  './terms.html',
+  './contact.html',
+  './stocks.html',
+  './manifest.json',
+  './styles.css'
 ];
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(urlsToCache))
+      .catch(err => console.error('Service Worker install failed:', err))
   );
 });
 

--- a/terms.html
+++ b/terms.html
@@ -12,6 +12,7 @@
             <div class="logo">AI Stock Analyzer</div>
             <ul>
                 <li><a href="index.html">ホーム</a></li>
+                <li><a href="stocks.html">銘柄一覧</a></li>
                 <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
                 <li><a href="terms.html">利用規約</a></li>
                 <li><a href="contact.html">お問い合わせ</a></li>


### PR DESCRIPTION
## Summary
- 新しいページ `stocks.html` を追加し、分析可能な銘柄一覧を表示
- 各ページのナビゲーションに「銘柄一覧」を追加
- サイトマップに `stocks.html` を追加
- サービスワーカーのキャッシュリストを相対パスへ更新し、インストールエラーを捕捉

## Testing
- `git status --short` で作業ツリーがクリーンであることを確認

------
https://chatgpt.com/codex/tasks/task_e_684de1dfb06c832e9e6eb2122fbfb928