### PR TITLE
Add mobile menu and market dashboard

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -10,8 +10,14 @@
     <header>
         <nav>
             <div class="logo">AI Stock Analyzer</div>
-            <ul>
+            <div class="menu-toggle" onclick="toggleMenu()">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+            <ul id="menu">
                 <li><a href="index.html">ホーム</a></li>
+                <li><a href="dashboard.html">マーケット概況</a></li>
                 <li><a href="stocks.html">銘柄一覧</a></li>
                 <li><a href="screener.html">スクリーニング</a></li>
                 <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
@@ -64,5 +70,11 @@
         <p>&copy; 2024 AI Stock Analyzer. All rights reserved.</p>
     </footer>
 
+    <script>
+        function toggleMenu() {
+            document.getElementById('menu').classList.toggle('active');
+        }
+    </script>
+
 </body>
-</html> 
+</html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>マーケット概況 - AI Stock Analyzer</title>
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { padding: 8px 12px; border: 1px solid #ddd; text-align: left; }
+        th { background: #f0f0f0; }
+    </style>
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="logo">AI Stock Analyzer</div>
+            <div class="menu-toggle" onclick="toggleMenu()">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+            <ul id="menu">
+                <li><a href="index.html">ホーム</a></li>
+                <li><a href="dashboard.html">マーケット概況</a></li>
+                <li><a href="stocks.html">銘柄一覧</a></li>
+                <li><a href="screener.html">スクリーニング</a></li>
+                <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
+                <li><a href="terms.html">利用規約</a></li>
+                <li><a href="contact.html">お問い合わせ</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section>
+            <h1>マーケット概況ダッシュボード</h1>
+            <p>主要指数や為替、原油価格などの一覧です。</p>
+            <table>
+                <thead>
+                    <tr><th>指標</th><th>値</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>日経平均株価</td><td>33,000</td></tr>
+                    <tr><td>TOPIX</td><td>2,300</td></tr>
+                    <tr><td>ドル/円</td><td>150.00</td></tr>
+                    <tr><td>原油先物</td><td>80.00</td></tr>
+                </tbody>
+            </table>
+            <h2>業種別騰落率</h2>
+            <table>
+                <thead>
+                    <tr><th>業種</th><th>騰落率</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>情報・通信</td><td>+1.5%</td></tr>
+                    <tr><td>輸送用機器</td><td>-0.8%</td></tr>
+                    <tr><td>銀行業</td><td>+0.3%</td></tr>
+                </tbody>
+            </table>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2024 AI Stock Analyzer. All rights reserved.</p>
+    </footer>
+
+    <script>
+        function toggleMenu() {
+            document.getElementById('menu').classList.toggle('active');
+        }
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -396,6 +396,26 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
+    <header>
+        <nav>
+            <div class="logo">AI Stock Analyzer</div>
+            <div class="menu-toggle" onclick="toggleMenu()">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+            <ul id="menu">
+                <li><a href="index.html">ホーム</a></li>
+                <li><a href="dashboard.html">マーケット概況</a></li>
+                <li><a href="stocks.html">銘柄一覧</a></li>
+                <li><a href="screener.html">スクリーニング</a></li>
+                <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
+                <li><a href="terms.html">利用規約</a></li>
+                <li><a href="contact.html">お問い合わせ</a></li>
+            </ul>
+        </nav>
+    </header>
+
     <div class="container">
         <!-- Header -->
         <div class="header">
@@ -1261,5 +1281,9 @@
         const changePercent = currentStock.data.info.changePercent.toFixed(2);
         
         return `🤖AI Stock Analyzerで${stockName}を分析！\n現在価格: ${price}円 (${change}${changePercent}%)\n\n#継続は力なり #株価分析 #AI投資`;
+    }
+
+    function toggleMenu() {
+        document.getElementById('menu').classList.toggle('active');
     }
 </script>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -10,8 +10,14 @@
     <header>
         <nav>
             <div class="logo">AI Stock Analyzer</div>
-            <ul>
+            <div class="menu-toggle" onclick="toggleMenu()">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+            <ul id="menu">
                 <li><a href="index.html">ホーム</a></li>
+                <li><a href="dashboard.html">マーケット概況</a></li>
                 <li><a href="stocks.html">銘柄一覧</a></li>
                 <li><a href="screener.html">スクリーニング</a></li>
                 <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
@@ -63,5 +69,11 @@
     <footer>
         <p>&copy; 2024 AI Stock Analyzer. All rights reserved.</p>
     </footer>
+
+    <script>
+        function toggleMenu() {
+            document.getElementById('menu').classList.toggle('active');
+        }
+    </script>
 </body>
-</html> 
+</html>

--- a/screener.html
+++ b/screener.html
@@ -50,8 +50,14 @@
     <header>
         <nav>
             <div class="logo">AI Stock Analyzer</div>
-            <ul>
+            <div class="menu-toggle" onclick="toggleMenu()">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+            <ul id="menu">
                 <li><a href="index.html">ホーム</a></li>
+                <li><a href="dashboard.html">マーケット概況</a></li>
                 <li><a href="stocks.html">銘柄一覧</a></li>
                 <li><a href="screener.html">スクリーニング</a></li>
                 <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
@@ -247,6 +253,9 @@
         });
 
         filterStocks();
+        function toggleMenu() {
+            document.getElementById('menu').classList.toggle('active');
+        }
     </script>
 </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -30,4 +30,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://appadaycreator.github.io/ai-stock-analyzer/dashboard.html</loc>
+    <lastmod>2025-06-14</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/stocks.html
+++ b/stocks.html
@@ -25,8 +25,14 @@
     <header>
         <nav>
             <div class="logo">AI Stock Analyzer</div>
-            <ul>
+            <div class="menu-toggle" onclick="toggleMenu()">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+            <ul id="menu">
                 <li><a href="index.html">ホーム</a></li>
+                <li><a href="dashboard.html">マーケット概況</a></li>
                 <li><a href="stocks.html">銘柄一覧</a></li>
                 <li><a href="screener.html">スクリーニング</a></li>
                 <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
@@ -162,6 +168,9 @@
         tr.innerHTML = `<td>${code}</td><td>${stockNames[code]}</td>`;
         tbody.appendChild(tr);
     });
+    function toggleMenu() {
+        document.getElementById('menu').classList.toggle('active');
+    }
     </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,7 @@ nav {
     justify-content: space-between;
     max-width: 1000px;
     margin: 0 auto;
+    position: relative;
 }
 
 .logo {
@@ -84,4 +85,37 @@ form textarea {
 
 .submit-button:hover {
     background: #3730a3;
+}
+/* Hamburger Menu */
+.menu-toggle {
+    display: none;
+    flex-direction: column;
+    cursor: pointer;
+}
+
+.menu-toggle span {
+    width: 25px;
+    height: 3px;
+    background: #fff;
+    margin: 4px 0;
+}
+
+@media (max-width: 768px) {
+    nav ul {
+        display: none;
+        flex-direction: column;
+        gap: 10px;
+        background: #4f46e5;
+        position: absolute;
+        top: 60px;
+        left: 0;
+        width: 100%;
+        padding: 10px 0;
+    }
+    nav ul.active {
+        display: flex;
+    }
+    .menu-toggle {
+        display: flex;
+    }
 }

--- a/terms.html
+++ b/terms.html
@@ -10,8 +10,14 @@
     <header>
         <nav>
             <div class="logo">AI Stock Analyzer</div>
-            <ul>
+            <div class="menu-toggle" onclick="toggleMenu()">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+            <ul id="menu">
                 <li><a href="index.html">ホーム</a></li>
+                <li><a href="dashboard.html">マーケット概況</a></li>
                 <li><a href="stocks.html">銘柄一覧</a></li>
                 <li><a href="screener.html">スクリーニング</a></li>
                 <li><a href="privacy-policy.html">プライバシーポリシー</a></li>
@@ -70,5 +76,11 @@
     <footer>
         <p>&copy; 2024 AI Stock Analyzer. All rights reserved.</p>
     </footer>
+
+    <script>
+        function toggleMenu() {
+            document.getElementById('menu').classList.toggle('active');
+        }
+    </script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- enable a responsive hamburger menu across pages
- add a new dashboard page for viewing market overview
- update sitemap with dashboard entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e097e50e8832e896e0e645a1b836b