### PR TITLE
Add comment toggle to stock info cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,11 +224,12 @@
             margin-bottom: 30px;
         }
         
-        .info-card {
+.info-card {
             background: linear-gradient(135deg, #f8fafc, #e2e8f0);
             padding: 20px;
             border-radius: 12px;
             text-align: center;
+            cursor: pointer;
         }
         
         .info-card h3 {
@@ -244,15 +245,16 @@
             font-weight: 700;
             color: #1e293b;
         }
+
+        .info-comment {
+            margin-top: 8px;
+            font-size: 0.8rem;
+            color: #475569;
+            display: none;
+        }
         
         .positive { color: #059669 !important; }
         .negative { color: #dc2626 !important; }
-        .info-icon {
-            margin-left: 4px;
-            cursor: pointer;
-            color: #4f46e5;
-            font-weight: bold;
-        }
         
         .chart-container {
             position: relative;
@@ -841,40 +843,48 @@
             
             // 株価情報表示
             const stockInfoHtml = `
-                <div class="info-card">
-                    <h3>現在価格 <span class="info-icon" onclick="showInfo('currentPrice')">?</span></h3>
+                <div class="info-card" onclick="toggleComment(this)">
+                    <h3>現在価格</h3>
                     <div class="value">${formatNumber(info.currentPrice)}円</div>
+                    <p class="info-comment">${infoDescriptions.currentPrice}</p>
                 </div>
-                <div class="info-card">
-                    <h3>前日比 <span class="info-icon" onclick="showInfo('change')">?</span></h3>
+                <div class="info-card" onclick="toggleComment(this)">
+                    <h3>前日比</h3>
                     <div class="value ${info.change >= 0 ? 'positive' : 'negative'}">
                         ${info.change >= 0 ? '+' : ''}${formatNumber(info.change)}円
                         (${info.changePercent >= 0 ? '+' : ''}${info.changePercent.toFixed(2)}%)
                     </div>
+                    <p class="info-comment">${infoDescriptions.change}</p>
                 </div>
-                <div class="info-card">
-                    <h3>出来高 <span class="info-icon" onclick="showInfo('volume')">?</span></h3>
+                <div class="info-card" onclick="toggleComment(this)">
+                    <h3>出来高</h3>
                     <div class="value">${formatVolume(info.volume)}</div>
+                    <p class="info-comment">${infoDescriptions.volume}</p>
                 </div>
-                <div class="info-card">
-                    <h3>PER <span class="info-icon" onclick="showInfo('per')">?</span></h3>
+                <div class="info-card" onclick="toggleComment(this)">
+                    <h3>PER</h3>
                     <div class="value">${info.per.toFixed(2)}倍</div>
+                    <p class="info-comment">${infoDescriptions.per}</p>
                 </div>
-                <div class="info-card">
-                    <h3>PBR <span class="info-icon" onclick="showInfo('pbr')">?</span></h3>
+                <div class="info-card" onclick="toggleComment(this)">
+                    <h3>PBR</h3>
                     <div class="value">${info.pbr.toFixed(2)}倍</div>
+                    <p class="info-comment">${infoDescriptions.pbr}</p>
                 </div>
-                <div class="info-card">
-                    <h3>ROE <span class="info-icon" onclick="showInfo('roe')">?</span></h3>
+                <div class="info-card" onclick="toggleComment(this)">
+                    <h3>ROE</h3>
                     <div class="value">${info.roe.toFixed(2)}%</div>
+                    <p class="info-comment">${infoDescriptions.roe}</p>
                 </div>
-                <div class="info-card">
-                    <h3>配当利回り <span class="info-icon" onclick="showInfo('dividendYield')">?</span></h3>
+                <div class="info-card" onclick="toggleComment(this)">
+                    <h3>配当利回り</h3>
                     <div class="value">${info.dividendYield.toFixed(2)}%</div>
+                    <p class="info-comment">${infoDescriptions.dividendYield}</p>
                 </div>
-                <div class="info-card">
-                    <h3>時価総額 <span class="info-icon" onclick="showInfo('marketCap')">?</span></h3>
+                <div class="info-card" onclick="toggleComment(this)">
+                    <h3>時価総額</h3>
                     <div class="value">${formatMarketCap(info.marketCap)}</div>
+                    <p class="info-comment">${infoDescriptions.marketCap}</p>
                 </div>
             `;
             
@@ -1268,8 +1278,11 @@
         marketCap: '発行済み株式数に株価を掛け合わせた企業の時価総額です。'
     };
 
-    function showInfo(key) {
-        alert(infoDescriptions[key]);
+    function toggleComment(card) {
+        const p = card.querySelector('.info-comment');
+        if (p) {
+            p.style.display = p.style.display === 'none' ? 'block' : 'none';
+        }
     }
 
     // SNSシェア機能


### PR DESCRIPTION
## Summary
- show descriptive comments when tapping stock info cards
- remove `?` icons and alert-based explanations

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684e31828560832ea5adc29ce800b7bc