### PR TITLE
Enable navigation from stock list to analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,7 +547,18 @@
             updateStockCount();
             renderFavorites();
             updateFavoriteButton();
-            
+
+            const params = new URLSearchParams(window.location.search);
+            const code = params.get('code');
+            const periodParam = params.get('period');
+            if (code) {
+                document.getElementById('stockCode').value = code;
+                if (periodParam) {
+                    document.getElementById('period').value = periodParam;
+                }
+                analyzeStock(code, periodParam || document.getElementById('period').value);
+            }
+
             // サービスワーカーの登録（PWA対応）
             if ('serviceWorker' in navigator) {
                 navigator.serviceWorker.register('sw.js').catch(console.error);

--- a/stocks.html
+++ b/stocks.html
@@ -166,7 +166,8 @@
     const tbody = document.getElementById('stockList');
     Object.keys(stockNames).sort().forEach(code => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${code}</td><td>${stockNames[code]}</td>`;
+        const plain = code.replace('.T', '');
+        tr.innerHTML = `<td><a href="index.html?code=${plain}">${code}</a></td><td>${stockNames[code]}</td>`;
         tbody.appendChild(tr);
     });
     function toggleMenu() {


### PR DESCRIPTION
## Summary
- link each stock code on the list to the analysis page
- auto-run analysis on `index.html` when `code` query parameter is provided

## Testing
- `tidy -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5d77c998832eaaf5e9a1d098d8ee